### PR TITLE
fix: update Chicago Taxi Dataset URL to Zenodo

### DIFF
--- a/exercises/exercise-3-EVALUATED.ipynb
+++ b/exercises/exercise-3-EVALUATED.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "and those levels have variable lengths: each taxi takes a different number of trips and each trip has a different number of points.\n",
     "\n",
-    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet](https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet)."
+    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://zenodo.org/records/14537442/files/chicago-taxi.parquet](https://zenodo.org/records/14537442/files/chicago-taxi.parquet)."
    ]
   },
   {
@@ -133,7 +133,7 @@
    ],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    row_groups=[0],\n",
     ")\n",
     "taxi"
@@ -176,7 +176,7 @@
    ],
    "source": [
     "ak.metadata_from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     ").metadata.num_row_groups"
    ]
   },
@@ -307,7 +307,7 @@
    ],
    "source": [
     "taxi_columns = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.path.*\"],\n",
     "    row_groups=[0],\n",
     ")\n",
@@ -393,7 +393,7 @@
    ],
    "source": [
     "ak.metadata_from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     ").form.columns()"
    ]
   },

--- a/exercises/exercise-3.ipynb
+++ b/exercises/exercise-3.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "and those levels have variable lengths: each taxi takes a different number of trips and each trip has a different number of points.\n",
     "\n",
-    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet](https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet)."
+    "Our dataset is formatted as a 611 MB [Apache Parquet](https://parquet.apache.org/) file, provided here: [https://zenodo.org/records/14537442/files/chicago-taxi.parquet](https://zenodo.org/records/14537442/files/chicago-taxi.parquet)."
    ]
   },
   {
@@ -122,7 +122,7 @@
    "outputs": [],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    row_groups=[0],\n",
     ")\n",
     "taxi"
@@ -154,7 +154,7 @@
    "outputs": [],
    "source": [
     "ak.metadata_from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     ").metadata.num_row_groups"
    ]
   },
@@ -240,7 +240,7 @@
    "outputs": [],
    "source": [
     "taxi_columns = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.path.*\"],\n",
     "    row_groups=[0],\n",
     ")\n",
@@ -281,7 +281,7 @@
    "outputs": [],
    "source": [
     "ak.metadata_from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     ").form.columns()"
    ]
   },

--- a/solutions/solution-3-EVALUATED.ipynb
+++ b/solutions/solution-3-EVALUATED.ipynb
@@ -98,7 +98,7 @@
    ],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.path.*\"],\n",
     "    row_groups=[0],\n",
     ")\n",

--- a/solutions/solution-3.ipynb
+++ b/solutions/solution-3.ipynb
@@ -58,7 +58,7 @@
    "outputs": [],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.path.*\"],\n",
     "    row_groups=[0],\n",
     ")\n",


### PR DESCRIPTION
Since we use this dataset a lot, I created a [Zenodo page](https://doi.org/10.5281/zenodo.14537441) for it.

[![](https://zenodo.org/badge/DOI/10.5281/zenodo.14537442.svg)](https://doi.org/10.5281/zenodo.14537441)

I'll need to delete the copy on AWS, so please accept this PR to update all of your URL references. Thanks!